### PR TITLE
Make public/private methods coherent

### DIFF
--- a/include/ADE7753.h
+++ b/include/ADE7753.h
@@ -254,38 +254,6 @@ class ADE7753 {
 		 */
 		uint8_t getVersion();
 
-
-		/**
-		 * @brief
-		 * 
-		 * @param Bit on Mode register.
-		 * 
-		 * @return 
-		 *     - ESP_OK Success
-		 *     - ESP_ERR_INVALID_ARG   if parameter is invalid
-		 */
-		esp_err_t setMode(uint16_t mode);
-
-
-		/**
-		 * @brief
-		 * 
-		 * @param Bit on Mode register.
-		 * 
-		 * @return 
-		 *     - ESP_OK Success
-		 *     - ESP_ERR_INVALID_ARG   if parameter is invalid
-		 */
-		esp_err_t clearMode(uint16_t mode);
-
-		/**
-		 * @brief Get MODE register values from ADE7753
-		 * 
-		 * @return data from the register (unsigned 16 bits)
-		 */
-		uint16_t getMode(void);
-
-
 		/**
 		 * @brief Reset ADE7753
 		 * 
@@ -619,6 +587,39 @@ class ADE7753 {
 		gpio_num_t _DIN = DEF_DIN;
 		gpio_num_t _SCLK = DEF_SCLK;
 		gpio_num_t _CS = DEF_CS;
+
+
+		/**
+		 * @brief
+		 * 
+		 * @param Bit on Mode register.
+		 * 
+		 * @return 
+		 *     - ESP_OK Success
+		 *     - ESP_ERR_INVALID_ARG   if parameter is invalid
+		 */
+		esp_err_t setMode(uint16_t mode);
+
+
+		/**
+		 * @brief
+		 * 
+		 * @param Bit on Mode register.
+		 * 
+		 * @return 
+		 *     - ESP_OK Success
+		 *     - ESP_ERR_INVALID_ARG   if parameter is invalid
+		 */
+		esp_err_t clearMode(uint16_t mode);
+
+		/**
+		 * @brief Get MODE register values from ADE7753
+		 * 
+		 * @return data from the register (unsigned 16 bits)
+		 */
+		uint16_t getMode(void);
+
+		
 		/**
 		 * 	Device activity flags
 		 * 


### PR DESCRIPTION
Hay varias formas de acceder a los registros del ADE7753. Por ejemplo, se puede hacer un `startMeasure(VOLTAGE)` y tambien se puede llamar a `getVRMS()`.

De la misma forma ocurre con `setMode()` y `startMeasure()`;

Mi propuesta es, si vamos a usar el metodo publico `startMeasure()`  entonces todos los operadores de los registros deberian quedar privados. Revisemos que metodos deberian quedar privados, que metodos deberian quedar publicos y que metodos no deberian existir.

- [x] getVersion
- [ ] reset
- [x] setGain
- [x] getGain
- [x] setIntegrator
- [x] getIntegrator
- [ ] getStatus
- [ ] getResetStatus
- [ ] getWaveform
- [ ] getVRMS
- [ ] getIRMS
- [ ] getPeriod
- [x] getFrequency
- [ ] setLineCyc
- [x] setZeroCrossingTimeout
- [x] getZeroCrossingTimeout
- [x] getSagCycles
- [x] setSagCycles
- [x] getSagVoltageLevel
- [x] setSagVoltageLevel
- [x] getIPeakLevel
- [x] setIPeakLevel
- [x] getVPeakLevel
- [x] setVPeakLevel
- [x] getIpeakReset
- [x] getVpeakReset
- [ ] setPotLine
- [ ] getWatt
- [x] getVar
- [x] getVa
- [ ] getInterrupt
- [ ] setInterrupt
- [ ] clearInterrupt
- [ ] getMaskInterrupt
- [x] configWaveform
- [ ] waveformSampleAvailable
- [x] getWaveformDataPtr
- [x] getWaveformDataTotalSamples
- [ ] getMeasuramentStatus
- [x] startMeasure
- [x] isrUpdate
- [x] getTemperature
- [x] getVrms
- [x] getIrms
- [x] setCyclesToMeasure
- [ ] destroyWaveformData
- [x] setZeroCrossingTimeoutIRQ
- [x] clearZeroCrossingTimeoutIRQ
- [ ] stopSampling
- [x] ZXISR
- [x] ZXTOUTISR
- [ ] transaction
- [ ] read8
- [ ] read16
- [ ] read24
- [ ] write8
- [ ] write16
- [ ] enableChip
- [ ] disableChip
- [ ] setMode
- [ ] clearMode
- [ ] getMode